### PR TITLE
[CORE-2237] Framework for separate development repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,3 +25,4 @@ workflows:
               only:
                 - release
                 - core-2237-author-enforcement-v2
+                - release-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+---
+version: 2.1
+
+executors:
+  deployer:
+    docker:
+      - image: cimg/base:2020.12
+
+jobs:
+  deploy-public-upstream:
+    executor: deployer
+    steps:
+      - checkout
+      - run:
+          name: Copy commits to destination repo
+          command: devops/scripts/deploy-public-upstream.sh
+
+workflows:
+  version: 2
+  deploy-public-upstream:
+    jobs:
+      - deploy-public-upstream:
+          filters:
+            branches:
+              only:
+                - release
+                - core-2237-author-enforcement-v2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,5 +24,3 @@ workflows:
             branches:
               only:
                 - release
-                - core-2237-author-enforcement-v2
-                - release-test

--- a/README-internal.md
+++ b/README-internal.md
@@ -1,0 +1,21 @@
+# Pantheon release process documentation
+
+There are some atypical development and release procedures in use with this repository:
+ 1. The currently released version of this repository lives in parallel in the `main` and `master` branches of
+    [pantheon-upstreams/drupal-project](https://github.com/pantheon-upstreams/drupal-project).  
+    `pantheon-upstreams/drupal-project` closely mirrors the development repository at [pantheon-systems/drupal-project](https://github.com/pantheon-systems/drupal-project)
+    and is automatically updated by a CircleCI process.
+ 1. Changes are made by submitting a PR against the `default` branch of `pantheon-systems/drupal-project`.
+ 1. Merging a PR to `default` _does not_ create a new release of `pantheon-upstreams/drupal-project`. This allows us to
+    batch more than one relatively small change into a single new "release" such that the number of separate update
+    events appearing on customer dashboards is more controlled.
+ 1. Trigger the new release to `pantheon-upstreams` by `--ff-only`-merging `default` into `release` and pushing the 
+    result.
+
+## Differences between `pantheon-upstreams` and `pantheon-systems` repos:
+ 1. Commits modifying the `.circleci` directory, `devops` directory or this file are omitted from `pantheon-upstreams`.
+    This prevents downstream Pantheon sites from being littered with our internal CI configuration, and allows us to
+    enhance CI without generating irrelevant site updates.
+    However, it means **you must not create commits that modify both .circleci and other files** in the same commit.
+ 2. Commit authors are rewritten to `Pantheon Automation <bot@getpantheon.com>` as a request from Product. The author
+    names appear on the dashboard and this creates a more professional presentation.

--- a/devops/scripts/commit-type.sh
+++ b/devops/scripts/commit-type.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Identifies a given commit as:
+# "normal" - changes meant for release to site upstreams
+# "nonrelease" - changes meant to modify CI or internal tooling
+# "mixed" - changes both of the above
+function identify_commit_type() {
+  local commit=$1
+  local has_normal_changes=0
+  local has_nonrelease_changes=0
+
+  affected_paths=$(git show "${commit}" --pretty=oneline --name-only | tail -n +2)
+  for path in $affected_paths; do
+      if [[ $path =~ ^.circleci/ || $path =~ ^devops/ || $path == "README-internal.md" ]] ; then
+        has_nonrelease_changes=1
+        continue
+      fi
+
+      has_normal_changes=1
+  done
+
+  if [[ $has_normal_changes -ne 0 && $has_nonrelease_changes -ne 0 ]]; then
+    echo "mixed"
+    return 0
+  fi
+
+  if [[ $has_normal_changes -ne 0 ]]; then
+    echo "normal"
+    return 0
+  fi
+
+  echo "nonrelease"
+}

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -52,7 +52,7 @@ for commit in "${commits[@]}"; do
 done
 
 # update the release-pointer
-git tag -f -m 'Last commit set on upstream repo' release-pointer "$commit"
+git tag -f -m 'Last commit set on upstream repo' release-pointer HEAD
 
 # Push released commits to a few branches on the upstream repo.
 # Since all commits to this repo are automated, it shouldn't hurt to put them on both branch names.

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 
 . devops/scripts/commit-type.sh
 
-git remote add public $UPSTREAM_REPO_REMOTE_URL
+git remote add public "$UPSTREAM_REPO_REMOTE_URL"
 git fetch public
-git checkout release
+git checkout "${CIRCLE_BRANCH}"
 
 # List commits between release-pointer and HEAD, in reverse
 newcommits=$(git log release-pointer..HEAD --reverse --pretty=format:"%h")
@@ -16,7 +16,7 @@ commits=()
 
 # Identify commits that should be released
 for commit in $newcommits; do
-  commit_type=$(identify_commit_type $commit)
+  commit_type=$(identify_commit_type "$commit")
   if [[ $commit_type == "normal" ]] ; then
     commits+=($commit)
   fi
@@ -58,7 +58,7 @@ git tag -f -m 'Last commit set on upstream repo' release-pointer "$commit"
 # Since all commits to this repo are automated, it shouldn't hurt to put them on both branch names.
 release_branches=('master' 'main')
 for branch in "${release_branches[@]}"; do
-  git push public public:$branch
+  git push public public:"$branch"
 done
 
 # Push release-pointer

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# This script is pretty tailored to assuming it's running in the CircleCI environment / a fresh git clone.
+# It mirrors most commits from `pantheon-systems/drupal-project:release` to `pantheon-upstreams/drupal-project`.
+
+set -euo pipefail
+
+. devops/scripts/commit-type.sh
+
+git remote add public $UPSTREAM_REPO_REMOTE_URL
+git fetch public
+git checkout release
+
+# List commits between release-pointer and HEAD, in reverse
+newcommits=$(git log release-pointer..HEAD --reverse --pretty=format:"%h")
+commits=()
+
+# Identify commits that should be released
+for commit in $newcommits; do
+  commit_type=$(identify_commit_type $commit)
+  if [[ $commit_type == "normal" ]] ; then
+    commits+=($commit)
+  fi
+
+  if [[ $commit_type == "mixed" ]] ; then
+    2>&1 echo "Commit ${commit} contains both release and nonrelease changes. Cannot proceed."
+    exit 1
+  fi
+done
+
+# If nothing found to release, bail without doing anything.
+if [[ ${#commits[@]} -eq 0 ]] ; then
+  echo "No new commits found to release"
+  echo "https://i.kym-cdn.com/photos/images/newsfeed/001/240/075/90f.png"
+  exit 1
+fi
+
+# Cherry-pick commits not modifying circle config onto the release branch
+git checkout -b public --track public/master
+git pull
+
+if [[ "$CIRCLECI" != "" ]]; then
+  git config --global user.email "bot@getpantheon.com"
+  git config --global user.name "Pantheon Automation"
+fi
+
+for commit in "${commits[@]}"; do
+  if [[ -z "$commit" ]] ; then
+    continue
+  fi
+  git cherry-pick "$commit" 2>&1
+  git commit --amend --no-edit --author='Pantheon Automation <bot@getpantheon.com>'
+done
+
+# update the release-pointer
+git tag -f -m 'Last commit set on upstream repo' release-pointer "$commit"
+
+# Push released commits to a few branches on the upstream repo.
+# Since all commits to this repo are automated, it shouldn't hurt to put them on both branch names.
+release_branches=('master' 'main')
+for branch in "${release_branches[@]}"; do
+  git push public public:$branch
+done
+
+# Push release-pointer
+git push -f origin release-pointer


### PR DESCRIPTION
**Problem**
Individual engineer names are appearing on the dashboard associated to available updates, where in the past official Pantheon upstreams said "Pantheon Automation"

**Solution**
Use two repositories, this one tracking the pristine history and a second one with automatically applied commits based on this one but with rewritten authors.

This approach also creates a clear path to adding additional CI or dev tooling that shouldn't pollute customer sites going forward.