### PR TITLE
[CORE-2255] Move drush from upstream-configuration to root

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     ],
     "require": {
-        "pantheon-upstreams/upstream-configuration": "*"
+        "pantheon-upstreams/upstream-configuration": "*",
+        "drush/drush": "^10"
     },
     "conflict": {
             "drupal/drupal": "*"

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -13,7 +13,6 @@
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",
         "pantheon-systems/drupal-integrations": "^9",
-        "drush/drush": "^10",
         "cweagans/composer-patches": "^1.0",
         "zaporylie/composer-drupal-optimizations": "^1.2"
     }


### PR DESCRIPTION
tl;dr: Customers are particularly likely to want to upgrade, downgrade,
or remove this component and so should be in the driver's seat.

https://pantheon.slack.com/archives/C1VB1GD3L/p1607633789107400