### PR TITLE
Allow sites to downgrade to Drupal 8.8

### DIFF
--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -11,8 +11,8 @@
         "php": ">=7.3",
         "composer/installers": "^1.8",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "^9",
-        "pantheon-systems/drupal-integrations": "^9",
+        "drupal/core-recommended": "^8.8 || ^9",
+        "pantheon-systems/drupal-integrations": "^8 || ^9",
         "drush/drush": "^10",
         "cweagans/composer-patches": "^1.0",
         "zaporylie/composer-drupal-optimizations": "^1.2"


### PR DESCRIPTION
A lot of sites are not yet ready to upgrade to Drupal 9.x.  It would be extra maintenance to create a fork of this upstream to allow for Integrated Composer sites based on Drupal 8. Instead, if we allow 8.8 or 9+ in the upstream configuration composer.json, that leaves the door open for sites to downgrade to Drupal 8 by adding a constraint to their project composer.json.

Note that I deliberately did not allow drupal/core-composer-scaffold to be downgraded. It's not harmful, and is usually helpful to use the latest scaffold plugin with an older version of Drupal. If desired, though, we could also add `^8.8 || ` to that component's constraint to avoid support requests from folks who might erroneously think they have to downgrade it, as an alternative to educating them. (I prefer the later strategy.)