### PR TITLE
[CORE-2258] Remove optimized autoloader configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
         }
     },
     "config": {
-        "optimize-autoloader": true,
         "preferred-install": "dist",
         "sort-packages": true,
         "platform": {


### PR DESCRIPTION
This was a good thing when we didn't force it in test/live, but is
probably a net negative now that we have distinct dev and test+live
build artifacts.