### PR TITLE
Enable deep patching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
             "web/private/scripts/quicksilver/{$name}/": ["type:quicksilver-script"]
         },
         "composer-exit-on-patch-failure": true,
+        "enable-patching": true,
         "patchLevel": {
             "drupal/core": "-p2"
         },


### PR DESCRIPTION
Enable patching so that our dependencies (e.g. pantheon-systems/drupal-integrations) may also add patches.

Note that modifying composer.json like this in the upstream carries the risk that users might encounter merge conflicts. The placement of the addition between two lines that are unlikely to be edited by the end user might decrease the odds of failure; however, any change to composer.json will always carry some risk. Since there are not too many Drupal 9 sites on the platform yet, it might be best to push this out soon before the number increases.

Motivation: We added a patch to pantheon-systems/drupal-integrations ^8 only to fix the MariaDB version reporting bug. This patch is not applied unless "enable-patching" is enabled in the root composer.json file. 
