### PR TITLE
BUGS-3865 - Integrated composer fails with Drupal 9.2.0 because of unignored file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ upstream/web/
 /web/.eslintignore
 /web/.eslintrc.json
 /web/.gitattributes
+/web/.gitignore
 /web/.ht.router.php
 /web/.htaccess
 /web/INSTALL.txt


### PR DESCRIPTION
BUGS-3865