### PR TITLE
Fix automation to keep separate git histories.

### DIFF
--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -56,15 +56,17 @@ done
 
 git commit -F /tmp/commit_message --author='Pantheon Automation <bot@getpantheon.com>'
 
-# update the release-pointer
-git tag -f -m 'Last commit set on upstream repo' release-pointer HEAD
-
 # Push released commits to a few branches on the upstream repo.
 # Since all commits to this repo are automated, it shouldn't hurt to put them on both branch names.
 release_branches=('master' 'main')
 for branch in "${release_branches[@]}"; do
   git push public public:"$branch"
 done
+
+git checkout $CIRCLE_BRANCH
+
+# update the release-pointer
+git tag -f -m 'Last commit set on upstream repo' release-pointer HEAD
 
 # Push release-pointer
 git push -f origin release-pointer


### PR DESCRIPTION
Do this by tagging release-pointer in the source repo instead of the destination repo.

Once merged, I should cleanup the tag in the destination repo and update it in the source repo in order to get everything ready for the next merge to release whenever it should happen.